### PR TITLE
Feature/fixed string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,11 @@ To make the regex case-insensitive::
 
   $ grin -i some_regex
 
+To search for a fixed-string pattern containing regex metacharacters
+without having to manually escape them::
+
+  $ grin -F '[string_with_regex_metachars('
+
 To output 2 lines of context before, after, or both before and after the
 matches::
 

--- a/grin/grin.py
+++ b/grin/grin.py
@@ -148,6 +148,14 @@ def get_grin_arg_parser(parser=None):
         help="ignore case in the regex",
     )
     parser.add_argument(
+        "-F",
+        "--fixed-string",
+        action="store_true",
+        dest="fixed_string",
+        default=False,
+        help="search pattern is fixed string, not regex",
+    )
+    parser.add_argument(
         "-A",
         "--after-context",
         default=0,

--- a/grin/options.py
+++ b/grin/options.py
@@ -59,4 +59,5 @@ default_options = Options(
     skip_symlink_dirs=True,
     skip_symlink_files=True,
     binary_bytes=4096,
+    re_flags=0,
 )

--- a/grin/utils.py
+++ b/grin/utils.py
@@ -92,4 +92,7 @@ def get_regex(args):
     flags = 0
     for flag in args.re_flags:
         flags |= flag
-    return re.compile(args.regex, flags)
+    pattern = args.regex
+    if args.fixed_string:
+        pattern = re.escape(pattern)
+    return re.compile(pattern, flags)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = grin3
 version = attr: grin.__version__
-url = https://bitbucket.org/rsalmaso/grin3
+url = https://github.com/rsalmaso/grin3
 download_url = https://pypi.org/project/grin3/
 author = Robert Kern
 author_email = robert.kern@enthought.com

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -84,6 +84,14 @@ bar
 """
 utf_8_foo = "Rémy\n".encode("utf8")
 latin_1_foo = "Rémy\n".encode("latin1")
+regex_metachar_foo = b"""bar
+bar
+def foo(...):
+bar
+foo
+bar
+bar
+"""
 
 
 class GrepTestCase(TestCase):
@@ -333,4 +341,14 @@ class GrepTestCase(TestCase):
         self.assertEqual(
             gt_after_context_1.do_grep(BytesIO(middle_of_line)),
             [(2, 0, "barfoobar\n", [(3, 6)]), (3, 1, "bar\n", None)],
+        )
+
+    def test_fixed_string_option(self):
+        # -F/--fixed-string works with unescaped regex metachars
+
+        options = grin.Options(fixed_string=True, regex="foo(", re_flags=[], before_context=0, after_context=0)
+        regex_with_metachars = grin.GrepText(grin.utils.get_regex(options))
+        self.assertEqual(
+            regex_with_metachars.do_grep(BytesIO(regex_metachar_foo)),
+            [(2, 0, 'def foo(...):\n', [(4, 8)])],
         )


### PR DESCRIPTION
Add -F/--fixed-string option to allow searching for a string without having to manually escape regex metacharacters, similar to `grep -F`.

I frequently find myself grepping for fixed strings containing regex metachars, the most common being searching for a function call that is a common word elsewhere in the code, and you don't. want all the extraneous matches:
```python
grin '\.replace\('
```
which becomes 
```python
grin -F '.replace('
```

Why not have the computer do the escaping for you?