### PR TITLE
Add word-matching (-w) and ASCII (-a) options.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,16 +120,6 @@ without having to manually escape them::
 
   $ grin -F '[string_with_regex_metachars('
 
-To search for a pattern that begins and ends on a word boundary (no partial-
-word matches):
-
-  $ grin -w myword
-
-By default, grin uses Unicode definitions of digits (\d,\D), word boundaries (\b,\B), etc.
-To force ASCII-only:
-
-  $ grin -a pattern
-
 To output 2 lines of context before, after, or both before and after the
 matches::
 

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,11 @@ whitespace (\s,\S), etc.  To force ASCII-only interpretation of these character 
 
   $ grin -a pattern
 
+To search for a pattern that begins and ends on a word boundary (no partial-
+word matches):
+
+  $ grin -w myword
+
 To output 2 lines of context before, after, or both before and after the
 matches::
 

--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,16 @@ without having to manually escape them::
 
   $ grin -F '[string_with_regex_metachars('
 
+To search for a pattern that begins and ends on a word boundary (no partial-
+word matches):
+
+  $ grin -w myword
+
+By default, grin uses Unicode definitions of digits (\d,\D), word boundaries (\b,\B), etc.
+To force ASCII-only:
+
+  $ grin -a pattern
+
 To output 2 lines of context before, after, or both before and after the
 matches::
 

--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,11 @@ without having to manually escape them::
 
   $ grin -F '[string_with_regex_metachars('
 
+By default, grin uses Unicode definitions of digits (\d,\D), word boundaries (\b,\B),
+whitespace (\s,\S), etc.  To force ASCII-only interpretation of these character classes:
+
+  $ grin -a pattern
+
 To output 2 lines of context before, after, or both before and after the
 matches::
 

--- a/grin/grin.py
+++ b/grin/grin.py
@@ -156,29 +156,6 @@ def get_grin_arg_parser(parser=None):
         help="search pattern is fixed string, not regex",
     )
     parser.add_argument(
-        "-u",
-        "--unicode",
-        action="store_true",
-        dest="unicode",
-        default=True,
-        help="enable Unicode definitions of digits, word boundaries, etc [default=%(default)r]",
-    )
-    parser.add_argument(
-        "-a",
-        "--ascii",
-        action="store_false",
-        dest="unicode",
-        help="enable ASCII definitions of digits, word boundaries, etc",
-    )
-    parser.add_argument(
-        "-w",
-        "--word-regexp",
-        action="store_true",
-        dest="word_regexp",
-        default=False,
-        help="match pattern only on word boundaries",
-    )
-    parser.add_argument(
         "-A",
         "--after-context",
         default=0,

--- a/grin/grin.py
+++ b/grin/grin.py
@@ -156,6 +156,29 @@ def get_grin_arg_parser(parser=None):
         help="search pattern is fixed string, not regex",
     )
     parser.add_argument(
+        "-u",
+        "--unicode",
+        action="store_true",
+        dest="unicode",
+        default=True,
+        help="enable Unicode definitions of digits, word boundaries, etc [default=%(default)r]",
+    )
+    parser.add_argument(
+        "-a",
+        "--ascii",
+        action="store_false",
+        dest="unicode",
+        help="enable ASCII definitions of digits, word boundaries, etc",
+    )
+    parser.add_argument(
+        "-w",
+        "--word-regexp",
+        action="store_true",
+        dest="word_regexp",
+        default=False,
+        help="match pattern only on word boundaries",
+    )
+    parser.add_argument(
         "-A",
         "--after-context",
         default=0,

--- a/grin/grin.py
+++ b/grin/grin.py
@@ -165,6 +165,14 @@ def get_grin_arg_parser(parser=None):
         help="search pattern is fixed string, not regex",
     )
     parser.add_argument(
+        "-w",
+        "--word-regexp",
+        action="store_true",
+        dest="word_regexp",
+        default=False,
+        help="match pattern only on word boundaries",
+    )
+    parser.add_argument(
         "-A",
         "--after-context",
         default=0,

--- a/grin/grin.py
+++ b/grin/grin.py
@@ -139,6 +139,15 @@ def get_grin_arg_parser(parser=None):
         help="show program's version number and exit",
     )
     parser.add_argument(
+        "-a",
+        "--ascii",
+        action="append_const",
+        dest="re_flags",
+        const=re.A,
+        default=[],
+        help="force ASCII-only definitions of digits, word boundaries, etc",
+    )
+    parser.add_argument(
         "-i",
         "--ignore-case",
         action="append_const",

--- a/grin/options.py
+++ b/grin/options.py
@@ -49,4 +49,6 @@ class Options(dict):
         self.setdefault("binary_bytes", 4096)
         self.setdefault("re_flags", [])
         self.setdefault("fixed_string", False)
+        self.setdefault("word_regexp", False)
+        self.setdefault("unicode", True)
         self.__dict__ = self

--- a/grin/options.py
+++ b/grin/options.py
@@ -49,4 +49,5 @@ class Options(dict):
         self.setdefault("binary_bytes", 4096)
         self.setdefault("re_flags", [])
         self.setdefault("fixed_string", False)
+        self.setdefault("word_regexp", False)
         self.__dict__ = self

--- a/grin/options.py
+++ b/grin/options.py
@@ -49,6 +49,4 @@ class Options(dict):
         self.setdefault("binary_bytes", 4096)
         self.setdefault("re_flags", [])
         self.setdefault("fixed_string", False)
-        self.setdefault("word_regexp", False)
-        self.setdefault("unicode", True)
         self.__dict__ = self

--- a/grin/utils.py
+++ b/grin/utils.py
@@ -98,9 +98,5 @@ def get_regex(args):
     flags = 0
     for flag in args.re_flags:
         flags |= flag
-    if not args.unicode:
-        flags |= re.ASCII
     pattern = re.escape(args.regex) if args.fixed_string else args.regex
-    if args.word_regexp:
-        pattern = r"\b" + pattern + r"\b"
     return re.compile(pattern, flags)

--- a/grin/utils.py
+++ b/grin/utils.py
@@ -98,5 +98,9 @@ def get_regex(args):
     flags = 0
     for flag in args.re_flags:
         flags |= flag
+    if not args.unicode:
+        flags |= re.ASCII
     pattern = re.escape(args.regex) if args.fixed_string else args.regex
+    if args.word_regexp:
+        pattern = r"\b" + pattern + r"\b"
     return re.compile(pattern, flags)

--- a/grin/utils.py
+++ b/grin/utils.py
@@ -99,4 +99,6 @@ def get_regex(args):
     for flag in args.re_flags:
         flags |= flag
     pattern = re.escape(args.regex) if args.fixed_string else args.regex
+    if args.word_regexp:
+        pattern = r"\b" + pattern + r"\b"
     return re.compile(pattern, flags)

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -96,7 +96,10 @@ unicode_digits = b"""This contains
 an Arabic-Indic digit \xd9\xa2 on the
 second line.
 """
-
+word_boundaries = b"""bar
+This is a test.
+baz
+"""
 
 class GrepTestCase(TestCase):
     def test_non_ascii(self):
@@ -375,4 +378,23 @@ class GrepTestCase(TestCase):
         self.assertEqual(
             regex_unicode.do_grep(BytesIO(unicode_digits)),
             [(1, 0, 'an Arabic-Indic digit ٢ on the\n', [(22, 23)])],
+        )
+
+    def test_word_match_option(self):
+        # -w/--word-regexp
+
+        # Not a word-match
+        options = grin.Options(word_regexp=True, regex="tes", re_flags=[], before_context=0, after_context=0)
+        regex_on_word_boundaries = grin.GrepText(grin.utils.get_regex(options))
+        self.assertEqual(
+            regex_on_word_boundaries.do_grep(BytesIO(word_boundaries)),
+            [],
+        )
+
+        # Word-match
+        options = grin.Options(word_regexp=True, regex="test", re_flags=[], before_context=0, after_context=0)
+        regex_on_word_boundaries = grin.GrepText(grin.utils.get_regex(options))
+        self.assertEqual(
+            regex_on_word_boundaries.do_grep(BytesIO(word_boundaries)),
+            [(1, 0, 'This is a test.\n', [(10, 14)])],
         )

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -92,6 +92,10 @@ foo
 bar
 bar
 """
+unicode_digits = b"""This contains
+an Arabic-Indic digit \xd9\xa2 on the
+second line.
+"""
 
 
 class GrepTestCase(TestCase):
@@ -351,4 +355,24 @@ class GrepTestCase(TestCase):
         self.assertEqual(
             regex_with_metachars.do_grep(BytesIO(regex_metachar_foo)),
             [(2, 0, "def foo(...):\n", [(4, 8)])],
+        )
+
+    def test_ascii(self):
+        # -a/--ascii
+
+        # No match when in ascii mode
+        options = grin.Options(regex=r"\d", re_flags=[re.A], before_context=0, after_context=0)
+        regex_unicode = grin.GrepText(grin.utils.get_regex(options))
+        self.assertEqual(
+            regex_unicode.do_grep(BytesIO(unicode_digits)),
+            [],
+        )
+        # [(1, 0, 'an Arabic-Indic digit ٢ on the\n', [(22, 23)])]
+
+        # Unicode (default)
+        options = grin.Options(regex=r"\d", re_flags=[], before_context=0, after_context=0)
+        regex_unicode = grin.GrepText(grin.utils.get_regex(options))
+        self.assertEqual(
+            regex_unicode.do_grep(BytesIO(unicode_digits)),
+            [(1, 0, 'an Arabic-Indic digit ٢ on the\n', [(22, 23)])],
         )

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -92,14 +92,6 @@ foo
 bar
 bar
 """
-word_boundaries = b"""bar
-This is a test.
-baz
-"""
-unicode_digits = b"""This contains
-an Arabic-Indic digit \xd9\xa2 on the
-second line.
-"""
 
 
 class GrepTestCase(TestCase):
@@ -359,43 +351,4 @@ class GrepTestCase(TestCase):
         self.assertEqual(
             regex_with_metachars.do_grep(BytesIO(regex_metachar_foo)),
             [(2, 0, "def foo(...):\n", [(4, 8)])],
-        )
-
-    def test_word_match_option(self):
-        # -w/--word-regexp
-
-        # Not a word-match
-        options = grin.Options(word_regexp=True, regex="tes", re_flags=[], before_context=0, after_context=0)
-        regex_on_word_boundaries = grin.GrepText(grin.utils.get_regex(options))
-        self.assertEqual(
-            regex_on_word_boundaries.do_grep(BytesIO(word_boundaries)),
-            [],
-        )
-
-        # Word-match
-        options = grin.Options(word_regexp=True, regex="test", re_flags=[], before_context=0, after_context=0)
-        regex_on_word_boundaries = grin.GrepText(grin.utils.get_regex(options))
-        self.assertEqual(
-            regex_on_word_boundaries.do_grep(BytesIO(word_boundaries)),
-            [(1, 0, 'This is a test.\n', [(10, 14)])],
-        )
-
-    def test_unicode(self):
-        # -u/--unicode
-
-        # No match when unicode not in effect
-        options = grin.Options(unicode=False, regex=r"\d", re_flags=[], before_context=0, after_context=0)
-        regex_unicode = grin.GrepText(grin.utils.get_regex(options))
-        self.assertEqual(
-            regex_unicode.do_grep(BytesIO(unicode_digits)),
-            [],
-        )
-        # [(1, 0, 'an Arabic-Indic digit ٢ on the\n', [(22, 23)])]
-
-        # Unicode (default)
-        options = grin.Options(regex=r"\d", re_flags=[], before_context=0, after_context=0)
-        regex_unicode = grin.GrepText(grin.utils.get_regex(options))
-        self.assertEqual(
-            regex_unicode.do_grep(BytesIO(unicode_digits)),
-            [(1, 0, 'an Arabic-Indic digit ٢ on the\n', [(22, 23)])],
         )


### PR DESCRIPTION
This adds -w/--word-regexp options to only match the pattern surrounded by word boundaries, like the GNU grep options with the same names.

In case you only want to use ASCII definitions of word boundaries (or other character classes like \d \D), it also adds the -a/--ascii option.

The handling of the -a option in `get_regex()` isn't particularly elegant, but it works.

Tests included.